### PR TITLE
Cleanup type naming. Add a `Value` to improve the API.

### DIFF
--- a/crates/mobius_egui/src/types.rs
+++ b/crates/mobius_egui/src/types.rs
@@ -1,13 +1,57 @@
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
-use std::sync::{Arc, Mutex};
+pub type Enqueue<T> = std::sync::mpsc::Sender<T>;
+pub type Dequeue<T> = std::sync::mpsc::Receiver<T>;
 
-pub type MobiusEnque<T> = std::sync::mpsc::Sender<T>;
-pub type MobiusDeque<T> = std::sync::mpsc::Receiver<T>;
+pub type EventEnqueue<T> = tokio::sync::mpsc::Sender<T>;
+pub type EventDequeue<T> = tokio::sync::mpsc::Receiver<T>;
 
-pub type MobiusEventEnque<T> = tokio::sync::mpsc::Sender<T>;
-pub type MobiusEventDeque<T> = tokio::sync::mpsc::Receiver<T>;
+pub struct Value<T>(Arc<Mutex<T>>);
 
-pub type MobiusString      = Arc<Mutex<String>>;
-//pub type MobiusSender<T>   = mpsc::Sender<T>; 
-//pub type MobiusReceiver<T> = mpsc::Receiver<T>;
+impl<T: Default> Default for Value<T> {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(T::default())))
+    }
+}
 
+impl<T> Clone for Value<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+
+impl<T> Value<T> {
+    // TODO avoid exposing `PoisonError` in the API here.
+    pub fn lock(&self) -> Result<ValueGuard<T>, PoisonError<MutexGuard<T>>> {
+        
+        let result = self.0.lock()
+            .map(|result|ValueGuard(result));
+        
+        result
+    }
+
+    pub fn new(value: T) -> Value<T> {
+        Self(Arc::new(Mutex::new(value)))
+    }
+}
+
+impl<T: Send> Value<T> {
+}
+
+pub struct ValueGuard<'a, T>(MutexGuard<'a, T>);
+
+impl<T> Deref for ValueGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T> DerefMut for ValueGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}

--- a/examples/simple_monitor/src/main.rs
+++ b/examples/simple_monitor/src/main.rs
@@ -8,6 +8,7 @@ mod ui_app;
 use ui_app::App;
 use mobius_egui::clear_logger;
 use mobius_egui::factory;
+use mobius_egui::types::Value;
 
 #[derive(Debug, Clone)]
 pub enum Command {
@@ -25,7 +26,7 @@ pub enum CommandResult {
 
 fn handle_command(
     command: Command,
-    logger_text: Arc<Mutex<String>>,
+    logger_text: Value<String>,
     local_index: &mut u32,
     shutdown_flag: Arc<AtomicBool>,
 ) {
@@ -83,7 +84,7 @@ fn main() {
     let shutdown_flag = Arc::new(AtomicBool::new(false));
 
     let app = App {
-        logger_text: Arc::new(Mutex::new(String::new())),
+        logger_text: Value::new(String::new()),
         command_sender: signal.sender.clone(),
     };
 

--- a/examples/simple_monitor/src/ui_app.rs
+++ b/examples/simple_monitor/src/ui_app.rs
@@ -1,12 +1,12 @@
 use eframe;
 use egui;
-use mobius_egui::types::{MobiusString, MobiusEnque}; 
+use mobius_egui::types::{Enqueue, Value}; 
 use mobius_egui::Signal;
 use crate::Command;
 
 pub struct App {
-    pub logger_text     : MobiusString,
-    pub command_sender  : MobiusEnque<Command>,
+    pub logger_text     : Value<String>,
+    pub command_sender  : Enqueue<Command>,
 }
 
 impl eframe::App for App {


### PR DESCRIPTION
naming as per discord discussion here: https://discord.com/channels/1255867192503832688/1255867192503832691/1343905059846754377

> also `MobiusEnque`/`MobiusDeque` should be `MobiusEnqueue`/`MobiusDequeue` respectively (spelling error)  (and also `MobiusEvent*`).

value api as per discord discussion here: https://discord.com/channels/1255867192503832688/1255867192503832691/1343905857750171720

> I think this is bad idea:
> ```rust
> pub type MobiusString      = Arc<Mutex<String>>;
> ```
> better would be to follow the Cushy pattern of `Dynamic<T>`, so you'd go:
> ```rust
> struct MyStruct
>     text: mobius::value::Dynamic<String>
> ```
>or something like that.