### PR TITLE
Avoid waiting for a fixed amount of time.

### DIFF
--- a/examples/signals_slots/src/main.rs
+++ b/examples/signals_slots/src/main.rs
@@ -1,4 +1,5 @@
-
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use mobius_egui::factory;
 use std::thread;
 
@@ -18,16 +19,26 @@ fn main() {
     // Create a signal and slot via the mobius_egui factory function
     let (signal, slot) = factory::create_signal_slot::<String>();
 
-    // Define a handler function for the slot
+    let shutdown_flag: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+    
+    // Start the slot with a handler
     // Note : since the handler takes Fn() as input, it can be a closure or a function
     // The handler function will be called whenever a command is sent to the slot, but the 
     // caller of the handler function is the slot itself.
-    let handler = |command: String| {
-        println!("Handled command: {}", command);
-    };
+    // here we use a closure due to needing a clone of the shutdown flag.
+    slot.start({
+        // clone the flag for the scope of the handler, which is moved into the closure below
+        let shutdown_flag = shutdown_flag.clone();
 
-    // Start the slot with the handler
-    slot.start(handler);
+        // Define a handler closure for the slot
+        move |command: String| {
+            println!("Handled command: {}", command);
+
+            if command.contains("shutdown") {
+                shutdown_flag.clone().store(true, Ordering::Relaxed)
+            }
+        }
+    });
 
     // Send a single command
     if let Err(e) = signal.send("Command 1".to_string()) {
@@ -39,6 +50,14 @@ fn main() {
         eprintln!("Error sending commands: {}", e);
     }
 
-    // Give some time for the commands to be processed
-    thread::sleep(std::time::Duration::from_secs(1));
+    if let Err(e) = signal.send("shutdown".to_string()) {
+        eprintln!("Error sending shutdown command: {}", e);
+    }
+
+    // Wait for the shutdown flag to be set.
+    // Note: there are other ways to achieve this without manual polling, such as using `CondVar` from the 'parking_lot' crate 
+    //       See https://docs.rs/parking_lot/latest/parking_lot/struct.Condvar.html
+    while !shutdown_flag.load(Ordering::Relaxed) {
+        thread::sleep(std::time::Duration::from_millis(1));
+    }
 }


### PR DESCRIPTION
Prior to this the example would fail if the system running the example was loaded/busy/slow.

See discord discussion: https://discord.com/channels/1255867192503832688/1255867192503832691/1343901969860792350

This works around the issue until some form of proper shutdown is implemented.